### PR TITLE
manage availability of entities and integration at startup

### DIFF
--- a/custom_components/hdhomerun/__main__.py
+++ b/custom_components/hdhomerun/__main__.py
@@ -26,14 +26,15 @@ async def main():
     _LOGGER.debug("entered")
 
     discovery = Discover(mode=DiscoverMode.AUTO)
-    # device = HDHomeRunDevice(host="192.168.123.254")
-    # await discovery.rediscover(target=device)
-    # devices: List[HDHomeRunDevice] = [device]
-    devices: List[HDHomeRunDevice] = await discovery.discover(broadcast_address="192.168.123.255")
+    device = HDHomeRunDevice(host="192.168.123.72")
+    await discovery.rediscover(target=device)
+    devices: List[HDHomeRunDevice] = [device]
+    # devices: List[HDHomeRunDevice] = await discovery.discover(broadcast_address="192.168.123.255")
     for dev in devices:
         def print_overview() -> None:
             print(dev.device_id)
             print('-' * len(dev.device_id))
+            print("Online:", dev.online)
             print("FriendlyName:", dev.friendly_name)
             print("IP:", dev.ip)
             print("Type:", dev.device_type)

--- a/custom_components/hdhomerun/binary_sensor.py
+++ b/custom_components/hdhomerun/binary_sensor.py
@@ -87,14 +87,20 @@ class HDHomerunBinarySensor(HDHomerunEntity, BinarySensorEntity):
 
     # region #-- properties --#
     @property
+    def available(self) -> bool:
+        """"""
+
+        return self._device.online
+
+    @property
     def is_on(self) -> bool:
         """Return if the service is on."""
 
-        if self._data:
+        if self._device:
             if self.entity_description.key:
-                return self.entity_description.state_value(getattr(self._data, self.entity_description.key, None))
+                return self.entity_description.state_value(getattr(self._device, self.entity_description.key, None))
             else:
-                return self.entity_description.state_value(self._data)
+                return self.entity_description.state_value(self._device)
         else:
             return False
     # endregion

--- a/custom_components/hdhomerun/update.py
+++ b/custom_components/hdhomerun/update.py
@@ -76,10 +76,16 @@ class HDHomerunUpdate(HDHomerunEntity, UpdateEntity, ABC):
                                f"{slugify(self.entity_description.name)}"
 
     @property
+    def available(self) -> bool:
+        """"""
+
+        return self._device.online
+
+    @property
     def installed_version(self) -> str | None:
         """Get the currently installed firmware version"""
 
-        return self._data.installed_version
+        return self._device.installed_version
 
     @property
     def latest_version(self) -> str | None:
@@ -88,7 +94,7 @@ class HDHomerunUpdate(HDHomerunEntity, UpdateEntity, ABC):
         N.B. this is set to the currently installed version if not found
         """
 
-        return self._data.latest_version or self.installed_version
+        return self._device.latest_version or self.installed_version
 
 
 async def async_setup_entry(


### PR DESCRIPTION
Report ConfigNotReady at startup
Fail the DUC if exception experienced
Implement `available` property for entities